### PR TITLE
Change all keyup events to keydown

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -781,16 +781,10 @@
           case 9:
             //  tab
             return this.onTab();
-        }
-      },
-
-      /**
-       * Search 'input' KeyBoardEvent handler.
-       * @param e {KeyboardEvent}
-       * @return {Function}
-       */
-      onSearchKeyUp (e) {
-        switch (e.keyCode) {
+          case 13:
+            //  enter.prevent
+            e.preventDefault();
+            return this.typeAheadSelect();
           case 27:
             //  esc
             return this.onEscape();
@@ -802,10 +796,6 @@
             //  down.prevent
             e.preventDefault();
             return this.typeAheadDown();
-          case 13:
-            //  enter.prevent
-            e.preventDefault();
-            return this.typeAheadSelect();
         }
       }
     },
@@ -884,7 +874,6 @@
             },
             events: {
               'keydown': this.onSearchKeyDown,
-              'keyup': this.onSearchKeyUp,
               'blur': this.onSearchBlur,
               'focus': this.onSearchFocus,
               'input': (e) => this.search = e.target.value

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -13,7 +13,7 @@ export const searchSubmit = (Wrapper, searchText = false) => {
   if (searchText) {
     Wrapper.vm.search = searchText;
   }
-  Wrapper.find({ ref: "search" }).trigger("keyup.enter")
+  Wrapper.find({ ref: "search" }).trigger("keydown.enter")
 };
 
 /**

--- a/tests/unit/Dropdown.spec.js
+++ b/tests/unit/Dropdown.spec.js
@@ -109,14 +109,14 @@ describe("Toggling Dropdown", () => {
     expect(spy).toHaveBeenCalled();
   });
 
-  it("should remove existing search text on escape keyup", () => {
+  it("should remove existing search text on escape keydown", () => {
     const Select = selectWithProps({
       value: [{ label: "one" }],
       options: [{ label: "one" }]
     });
 
     Select.vm.search = "foo";
-    Select.find('.vs__search').trigger('keyup.esc')
+    Select.find('.vs__search').trigger('keydown.esc')
     expect(Select.vm.search).toEqual("");
   });
 

--- a/tests/unit/TypeAhead.spec.js
+++ b/tests/unit/TypeAhead.spec.js
@@ -23,7 +23,7 @@ describe("Moving the Typeahead Pointer", () => {
 
     Select.vm.typeAheadPointer = 1;
 
-    Select.find({ ref: "search" }).trigger("keyup.up");
+    Select.find({ ref: "search" }).trigger("keydown.up");
 
     expect(Select.vm.typeAheadPointer).toEqual(0);
   });
@@ -33,7 +33,7 @@ describe("Moving the Typeahead Pointer", () => {
 
     Select.vm.typeAheadPointer = 1;
 
-    Select.find({ ref: "search" }).trigger("keyup.down");
+    Select.find({ ref: "search" }).trigger("keydown.down");
 
     expect(Select.vm.typeAheadPointer).toEqual(2);
   });
@@ -53,7 +53,7 @@ describe("Moving the Typeahead Pointer", () => {
 
       Select.vm.typeAheadPointer = 1;
 
-      Select.find({ ref: "search" }).trigger("keyup.up");
+      Select.find({ ref: "search" }).trigger("keydown.up");
       expect(spy).toHaveBeenCalled();
     });
 
@@ -63,7 +63,7 @@ describe("Moving the Typeahead Pointer", () => {
 
       Select.vm.typeAheadPointer = 1;
 
-      Select.find({ ref: "search" }).trigger("keyup.down");
+      Select.find({ ref: "search" }).trigger("keydown.down");
       expect(spy).toHaveBeenCalled();
     });
 


### PR DESCRIPTION
For a few reasons:

- event.preventDefault() for the Enter key (to stop it from submitting
  the form when you select an item) is only effective if it's a keydown
  event.

- Using keydown for up/down navigation means you can hold them down to
  rapidly scroll through a lot of items.

- Keydown events make the UX feel more responsive, and is consistent
  with how most apps/operating systems handle key presses.